### PR TITLE
fix: Fixed 'NoneType' Sender in LLMService.py

### DIFF
--- a/src/LLMService.py
+++ b/src/LLMService.py
@@ -134,7 +134,8 @@ class OpenAIService(LLMService):
                 for chunk in response:
                     chunk_message = chunk['choices'][0]['delta'].get("content", None)  # extract the message
                     if chunk_message is not None:
-                        self.sender.send_message(msg_type=MSG_TYPE_OPEN_AI_STREAM, msg=chunk_message)
+                        if self.sender is not None:
+                            self.sender.send_message(msg_type=MSG_TYPE_OPEN_AI_STREAM, msg=chunk_message)
                         collected_messages.append(chunk_message)  # save the message
 
                 full_reply_content = ''.join(collected_messages)


### PR DESCRIPTION
Fixed a bug when trying to run the ./src/main.py script which returns: 'NoneType' object has no attribute 'send_message'